### PR TITLE
Багнется не багнется багнется не багнется v2

### DIFF
--- a/server/api/application/db/DB.php
+++ b/server/api/application/db/DB.php
@@ -159,7 +159,7 @@ class DB {
         return $this->queryAll(
             "SELECT id, type, status, current_member_id, privatecode, hash 
              FROM rooms 
-             WHERE type='open' AND (status='waiting' OR status='playing')",
+             WHERE type='open' AND (status='waiting' OR status='waiting_for_bets' OR status='playing' OR status='show_results')",
             []
         );
     }
@@ -283,7 +283,19 @@ class DB {
 
     public function addRoomMember($roomId, $userId, $status = 'spectator', $bet = 0) {
         try {
+            // Проверяем, не находится ли пользователь уже в этой комнате
+            $existingMember = $this->getRoomMember($roomId, $userId);
+            
+            if ($existingMember) {
+                // Пользователь уже в комнате, ничего не делаем
+                // Сохраняем его текущие данные (ставку, карты и т.д.)
+                return true;
+            }
+            
+            // Удаляем пользователя из других комнат
             $this->execute("DELETE FROM roommembers WHERE userid = ? AND roomid != ?", [$userId, $roomId]);
+            
+            // Добавляем в текущую комнату
             return $this->execute(
                 "INSERT INTO roommembers (roomid, userid, status, bet, cards) VALUES (?, ?, ?, ?, '')",
                 [$roomId, $userId, $status, $bet]

--- a/server/api/application/db/DB.php
+++ b/server/api/application/db/DB.php
@@ -205,6 +205,11 @@ class DB {
         return $this->execute("UPDATE rooms SET hash = ?, last_update = UTC_TIMESTAMP() WHERE id = ?", [$hash, $roomId]);
     }
 
+    public function updateRoomHashOnly($roomId, $hash) {
+        // Обновляет только hash, НЕ трогая last_update (для комнат с активными таймерами)
+        return $this->execute("UPDATE rooms SET hash = ? WHERE id = ?", [$hash, $roomId]);
+    }
+
     public function updateRoomStatus($roomId, $status) {
         $hash = md5(time() . $roomId . rand(1, 10000));
         return $this->execute(
@@ -221,6 +226,15 @@ class DB {
         $newHash = md5(time() . $roomId . rand(1, 10000));
         return $this->execute(
             "UPDATE rooms SET hash = ?, last_update = UTC_TIMESTAMP() WHERE id = ?",
+            [$newHash, $roomId]
+        );
+    }
+
+    public function updateRoomActionOnly($roomId) {
+        // Обновляет только hash, НЕ трогая last_update (для фаз с таймером)
+        $newHash = md5(time() . $roomId . rand(1, 10000));
+        return $this->execute(
+            "UPDATE rooms SET hash = ? WHERE id = ?",
             [$newHash, $roomId]
         );
     }

--- a/server/api/application/game/Player.php
+++ b/server/api/application/game/Player.php
@@ -296,8 +296,10 @@ class Player {
     }
     
     private function finishRound($roomId) {
+        // Дилер должен взять карты перед расчетом результатов
+        $this->db->resetCurrentMember($roomId);
+        $this->dealerTakeCard($roomId);
         $this->calculateAndPayResults($roomId);
-        
     }
 
     public function pass($roomId, $userId) {

--- a/server/api/application/game/Player.php
+++ b/server/api/application/game/Player.php
@@ -51,6 +51,9 @@ class Player {
             // Если это первая ставка, переводим комнату в waiting_for_bets
             if ($room->status === 'waiting') {
                 $this->db->updateRoomStatus($roomId, 'waiting_for_bets');
+            } else if ($room->status === 'waiting_for_bets') {
+                // В фазе ставок НЕ обновляем last_update (не сбрасываем таймер)
+                $this->db->updateRoomActionOnly($roomId);
             } else {
                 $this->db->updateRoomAction($roomId);
             }

--- a/server/api/application/game/Player.php
+++ b/server/api/application/game/Player.php
@@ -353,6 +353,7 @@ class Player {
             return ['error' => 804];
         }
 
+        $originalBet = $member->bet;
         $this->db->updateMemberBet($roomId, $userId, $member->bet * 2);
         $this->db->updateBalance($userId, -$member->bet);
 
@@ -363,6 +364,7 @@ class Player {
 
         $currentCards[] = $newCard;
         $this->db->updateMemberCards($roomId, $userId, $currentCards);
+        
         $this->db->updateRoomAction($roomId);
         $this->moveToNextPlayer($roomId);
 
@@ -392,6 +394,7 @@ class Player {
         }
         
         $this->db->updateDealerCards($roomId, $dealerCards);
+        
         return ['success' => true];
     }
     

--- a/server/api/application/game/gameLogic.php
+++ b/server/api/application/game/gameLogic.php
@@ -122,7 +122,8 @@ class GameLogic {
                     if ($member->status === 'player' && (int)$member->bet === 0) {
                         $this->db->updateMemberStatus($roomId, $member->user_id, 'spectator');
                     }
-                    if ($member->status !== 'spectator') {
+                    // Считаем игроков со ставками (независимо от статуса подключения)
+                    if ((int)$member->bet > 0) {
                         $playersLeft++;
                     }
                 }

--- a/server/api/application/lobby/Lobby.php
+++ b/server/api/application/lobby/Lobby.php
@@ -58,9 +58,26 @@ class Lobby {
     // ============================================================
 
     public function quickStart($userId) {
-        // if ($this->isUserPlaying($userId)) {
-        //     return ['error' => 800];
-        // }
+        // Проверяем, не находится ли пользователь уже в комнате
+        $existingRoomData = $this->db->getRoomId($userId);
+        if ($existingRoomData && $existingRoomData->roomid) {
+            $existingRoom = $this->db->getRoom($existingRoomData->roomid);
+            $existingMember = $this->db->getRoomMember($existingRoomData->roomid, $userId);
+            
+            // Если пользователь в комнате со ставкой или игра идёт, возвращаем эту комнату
+            if ($existingRoom && $existingMember) {
+                $roomIsActive = in_array($existingRoom->status, ['waiting', 'waiting_for_bets', 'playing', 'show_results']);
+                $userHasBet = $existingMember->bet > 0;
+                
+                if ($roomIsActive && ($userHasBet || $existingRoom->status === 'playing')) {
+                    // Обновляем хэш комнаты для синхронизации
+                    $this->refreshRoomHash($existingRoomData->roomid);
+                    return $this->db->getRoom($existingRoomData->roomid);
+                }
+            }
+        }
+        
+        // Пользователь не в активной комнате или там нет ставки - удаляем из всех комнат
         $this->db->removeUserFromAllRooms($userId);
         $room = $this->getOpenRoom();
         $isNewRoom = false;
@@ -112,9 +129,26 @@ class Lobby {
     }
 
     public function createPrivateRoom($userId) {
-        // if ($this->isUserPlaying($userId)) {
-        //     return ['error' => 800];
-        // }
+        // Проверяем, не находится ли пользователь уже в активной комнате со ставкой
+        $existingRoomData = $this->db->getRoomId($userId);
+        if ($existingRoomData && $existingRoomData->roomid) {
+            $existingRoom = $this->db->getRoom($existingRoomData->roomid);
+            $existingMember = $this->db->getRoomMember($existingRoomData->roomid, $userId);
+            
+            if ($existingRoom && $existingMember) {
+                $roomIsActive = in_array($existingRoom->status, ['waiting', 'waiting_for_bets', 'playing', 'show_results']);
+                $userHasBet = $existingMember->bet > 0;
+                
+                if ($roomIsActive && ($userHasBet || $existingRoom->status === 'playing')) {
+                    // Пользователь уже в активной игре, нельзя создавать новую комнату
+                    return ['error' => 800];
+                }
+            }
+        }
+        
+        // Удаляем из всех комнат перед созданием новой
+        $this->db->removeUserFromAllRooms($userId);
+        
         $attempts = 0;
         $privateCode = null;
         do {
@@ -165,9 +199,29 @@ class Lobby {
     }
 
     public function joinPrivateRoom($userId, $code) {
-        // if ($this->isUserPlaying($userId)) {
-        //     return ['error' => 800];
-        // }
+        // Проверяем, не находится ли пользователь уже в активной комнате со ставкой
+        $existingRoomData = $this->db->getRoomId($userId);
+        if ($existingRoomData && $existingRoomData->roomid) {
+            $existingRoom = $this->db->getRoom($existingRoomData->roomid);
+            $existingMember = $this->db->getRoomMember($existingRoomData->roomid, $userId);
+            
+            if ($existingRoom && $existingMember) {
+                $roomIsActive = in_array($existingRoom->status, ['waiting', 'waiting_for_bets', 'playing', 'show_results']);
+                $userHasBet = $existingMember->bet > 0;
+                
+                if ($roomIsActive && ($userHasBet || $existingRoom->status === 'playing')) {
+                    // Пользователь уже в активной игре
+                    // Если это та же комната, просто возвращаем её
+                    $targetRoom = $this->db->getRoomByPrivateCode(strtoupper($code));
+                    if ($targetRoom && $targetRoom->id == $existingRoomData->roomid) {
+                        $this->refreshRoomHash($existingRoomData->roomid);
+                        return $this->db->getRoom($existingRoomData->roomid);
+                    }
+                    // Иначе возвращаем ошибку
+                    return ['error' => 800];
+                }
+            }
+        }
         
         $code = strtoupper($code);
         if (!preg_match('/^[A-Z]{4}$/', $code)) {
@@ -222,6 +276,19 @@ class Lobby {
             return ['error' => 901];
         }
 
+        // Проверяем, можно ли удалить игрока из комнаты
+        $member = $this->db->getRoomMember($roomId, $userId);
+        $roomIsActive = in_array($room->status, ['waiting_for_bets', 'playing', 'show_results']);
+        $userHasBet = $member && $member->bet > 0;
+
+        // Если у игрока есть ставка и игра активна, НЕ удаляем его из комнаты
+        if ($roomIsActive && $userHasBet) {
+            // Игрок остаётся в комнате, просто отключается
+            // Когда он вернётся, он автоматически переподключится к той же комнате
+            return ['success' => true, 'stayed_in_room' => true];
+        }
+
+        // В остальных случаях удаляем игрока из комнаты
         $this->db->removeUserFromRoom($roomId, $userId);
 
         $membersCount = $this->db->getMembersCount($roomId);

--- a/server/api/application/lobby/Lobby.php
+++ b/server/api/application/lobby/Lobby.php
@@ -53,6 +53,13 @@ class Lobby {
         return $success ? $newHash : false;
     }
 
+    private function refreshRoomHashOnly($roomId) {
+        // Обновляет только hash, НЕ трогая last_update (для комнат с активными таймерами)
+        $newHash = md5(microtime(true) . rand(1000, 9999) . $roomId);
+        $success = $this->db->updateRoomHashOnly($roomId, $newHash);
+        return $success ? $newHash : false;
+    }
+
     // ============================================================
     // PUBLIC METHODS
     // ============================================================
@@ -71,7 +78,13 @@ class Lobby {
                 
                 if ($roomIsActive && ($userHasBet || $existingRoom->status === 'playing')) {
                     // Обновляем хэш комнаты для синхронизации
-                    $this->refreshRoomHash($existingRoomData->roomid);
+                    // Для комнат с таймером (waiting_for_bets, show_results) НЕ обновляем last_update
+                    $hasTimer = in_array($existingRoom->status, ['waiting_for_bets', 'show_results']);
+                    if ($hasTimer) {
+                        $this->refreshRoomHashOnly($existingRoomData->roomid);
+                    } else {
+                        $this->refreshRoomHash($existingRoomData->roomid);
+                    }
                     return $this->db->getRoom($existingRoomData->roomid);
                 }
             }
@@ -214,7 +227,13 @@ class Lobby {
                     // Если это та же комната, просто возвращаем её
                     $targetRoom = $this->db->getRoomByPrivateCode(strtoupper($code));
                     if ($targetRoom && $targetRoom->id == $existingRoomData->roomid) {
-                        $this->refreshRoomHash($existingRoomData->roomid);
+                        // Для комнат с таймером НЕ обновляем last_update
+                        $hasTimer = in_array($existingRoom->status, ['waiting_for_bets', 'show_results']);
+                        if ($hasTimer) {
+                            $this->refreshRoomHashOnly($existingRoomData->roomid);
+                        } else {
+                            $this->refreshRoomHash($existingRoomData->roomid);
+                        }
                         return $this->db->getRoom($existingRoomData->roomid);
                     }
                     // Иначе возвращаем ошибку
@@ -242,7 +261,14 @@ class Lobby {
             return ['error' => 900];
         }
 
-        $newHash = $this->refreshRoomHash($room->id);
+        // Для комнат с таймером НЕ обновляем last_update
+        $hasTimer = in_array($room->status, ['waiting_for_bets', 'show_results']);
+        if ($hasTimer) {
+            $newHash = $this->refreshRoomHashOnly($room->id);
+        } else {
+            $newHash = $this->refreshRoomHash($room->id);
+        }
+        
         if ($newHash === false) {
             return ['error' => 808];
         }
@@ -256,7 +282,14 @@ class Lobby {
             return ['error' => 901];
         }
 
-        $newHash = $this->refreshRoomHash($roomId);
+        // Для комнат с таймером НЕ обновляем last_update
+        $hasTimer = in_array($roomData->status, ['waiting_for_bets', 'show_results']);
+        if ($hasTimer) {
+            $newHash = $this->refreshRoomHashOnly($roomId);
+        } else {
+            $newHash = $this->refreshRoomHash($roomId);
+        }
+        
         if ($newHash === false) {
             return ['error' => 808];
         }
@@ -295,7 +328,13 @@ class Lobby {
         if ($membersCount && $membersCount->count == 0) {
             $this->db->deleteRoom($roomId);
         } else {
-            $this->refreshRoomHash($roomId);
+            // Для комнат с таймером НЕ обновляем last_update
+            $hasTimer = in_array($room->status, ['waiting_for_bets', 'show_results']);
+            if ($hasTimer) {
+                $this->refreshRoomHashOnly($roomId);
+            } else {
+                $this->refreshRoomHash($roomId);
+            }
         }
 
         return ['success' => true];


### PR DESCRIPTION
[bugFix1] - исправление ситуации, когда при наличии в комнате >=2 юзеров при выходе одного игрока, поставившего ставку и при его повторной попытке входа через быструю игру, создавалась новая комната, вместо того, чтобы игрока переносило в комнату со ставкой
[bugFix2 - исправление bugFix1, при повторном входе игрока из-за обновление lastUpdate в функции обновление хеша комнаты (updateRoomHash) таймеры в фазе waiting_for_bets и show_results сбрасывались до начальных значений (то есть 5 секунд и 10 секунд). Таким образом игрок мог бесконечно затягивать фазы ставок и показа результата путём многократных входов и выходов. Решено созданием отдельной функции (updateRoomHashOnly) обновления хеша без обновления lastUpdate